### PR TITLE
op() required to be const, libstdc++ enforces it

### DIFF
--- a/benchmarks/allocators/Makefile
+++ b/benchmarks/allocators/Makefile
@@ -1,9 +1,9 @@
 # You may need to set the following variables:
 #
-# CXX      - path to Clang++ 3.6
-# CC       - path to Clang 3.6
-# AR       - path to LLVM's 'ar' tool
-# RANLIB   - path to LLVM's 'ranlib' tool
+# CXX      - path to C++ compiler
+# CC       - path to C compiler
+# AR       - path to suitable 'ar' tool
+# RANLIB   - path to suitable 'ranlib' tool
 # BDEWAF   - path to 'waf' from BDE Tools (https://github.com/bloomberg/bde-tools)
 
 CXX = clang++-3.6
@@ -26,10 +26,12 @@ BDLINC = $(INST)/include/bdl
 BSLLIB = $(BSLSRC)/build/groups/bsl
 BDLLIB = $(BSLSRC)/build/groups/bdl
 
+# comment this out for gcc-5:
 STDLIB = -stdlib=libc++
-# If libc++ was built from source (not installed from a system package), then libc++abi may not
-# have been linked into libc++. In this situation, the linker must explicitly be told to include
-# it in the link, by uncommenting the line below.
+# If libc++ was built from source (not installed from a system package),
+# then libc++abi may not have been linked into libc++. In this situation, the
+# linker must be explicitly told to include it in the link, by uncommenting
+# the line below.
 #STDLIBABI = -lc++abi
 
 INCLUDES = \

--- a/benchmarks/allocators/README.md
+++ b/benchmarks/allocators/README.md
@@ -6,17 +6,21 @@ These are the programs used to produce the results found in
 fixed since the paper was produced, so may not produce identical results.
 
 These programs depend upon:
-  * Clang version 3.6 or later, with support for link-time-optimization (LTO, see FAQ)
-  * libc++ version 3.6 or later
-  * [BDE Tools](https://github.com/bloomberg/bde-tools), which contains a 
+  * Clang version 3.6 or later, or gcc version 5.1 or later, built with
+   support for link-time-optimization (LTO, see FAQ)
+  * For clang, libc++ version 3.6, or later
+  * For gcc 5.1, libstdc++ patched according to:
+   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66055
+  * [BDE Tools](https://github.com/bloomberg/bde-tools), which contains a
     custom build system based on [waf](https://github.com/waf-project/waf)
+  * If building for LTO, /usr/bin/ld indicating ld.gold
 
 A suitably-configured system can be built quickly using 
 [Docker](https://docker.com); see the 'Docker' section below for instructions.
 
-This repository contains a snapshot of the BDE library, which has been patched 
-to make use of various C++14 features required for the benchmark programs. 
-The patches are included separately here in the [bde-patches-minimal] and 
+This repository contains a snapshot of the BDE library patched to make use
+of various C++14 features required for the benchmark programs.  The patches
+are included separately here in the [bde-patches-minimal] and 
 [bde-patches-opt] files.
 
 To configure,
@@ -99,20 +103,16 @@ FAQ
 ===
 Q1: What about tcmalloc?
 
-A1: In all our tests, tcmalloc was substantially slower than libc++'s heap 
-    allocator.
+A1: In all our tests, tcmalloc was substantially slower than the default
+    new/delete on the target platform.
 
-Q2: Why do these depend on recent clang++ and libc++?
+Q2: Why do these depend on recent clang++/libc++ or g++/libstdc++?
 
 A2: The tests, particularly growth.cc and locality.cc, depend on features of
-  C++14, specifically the containers' comprehensive observance of allocator-
-  traits requirements to direct their memory management.  To our knowledge,
-  at the time of this writing libc++ is the only library implementation
-  that meets this requirement.  libc++, in turn, is most easily built with
-  clang++.
+  C++14: specifically, the containers' comprehensive observance of allocator-
+  traits requirements to direct their memory management.
 
-Q3: Can I build these with a non-LTO-enabled Clang/LLVM toolchain?
+Q3: How can I build these with a non-LTO-enabled toolchain?
 
-A3: Yes.  To do so, comment out the 'LLVM-AR' and 'LTO' variable declarations
-    in ```Makefile```.
+A3: Comment out the ```LTO``` variable value in ```Makefile```.
     

--- a/benchmarks/allocators/README.md
+++ b/benchmarks/allocators/README.md
@@ -15,7 +15,7 @@ These programs depend upon:
     custom build system based on [waf](https://github.com/waf-project/waf)
   * If building for LTO, /usr/bin/ld indicating ld.gold
 
-A suitably-configured system can be built quickly using 
+A suitably-configured system can be built quickly using
 [Docker](https://docker.com); see the 'Docker' section below for instructions.
 
 This repository contains a snapshot of the BDE library patched to make use

--- a/benchmarks/allocators/allocont.h
+++ b/benchmarks/allocators/allocont.h
@@ -22,6 +22,8 @@
 template <typename T, typename Pool>
 struct pool_adaptor {
     typedef T value_type;
+    typedef T& reference;
+    typedef T const& const_reference;
     Pool* pool;
     pool_adaptor() : pool(nullptr) {}
     pool_adaptor(Pool* poo) : pool(poo) {}

--- a/benchmarks/allocators/growth.cc
+++ b/benchmarks/allocators/growth.cc
@@ -231,9 +231,25 @@ double measure(int mask, bool csv, double reference, Test test)
     return ((mask & (SA|CT)) == (SA|CT)) ? result_time : reference;
 }
 
+#ifdef __GLIBCXX__
+namespace std {
+  template<typename C, typename T, typename A>
+    struct hash<basic_string<C, T, A>>
+    {
+      using result_type = size_t;
+      using argument_type = basic_string<C, T, A>;
+
+      result_type operator()(const argument_type& s) const noexcept
+      { return std::_Hash_impl::hash(s.data(), s.length()); }
+    };
+}
+#endif
+
 template <typename T>
 struct my_hash {
-    unsigned long operator()(T const& t) const
+    using result_type = size_t;
+    using argument_type = T;
+    result_type operator()(T const& t) const
         { return 1048583 * (1 + reinterpret_cast<unsigned long>(&t)); }
 };
 template <typename T>

--- a/benchmarks/allocators/growth.cc
+++ b/benchmarks/allocators/growth.cc
@@ -233,12 +233,12 @@ double measure(int mask, bool csv, double reference, Test test)
 
 template <typename T>
 struct my_hash {
-    unsigned long operator()(T const& t)
+    unsigned long operator()(T const& t) const
         { return 1048583 * (1 + reinterpret_cast<unsigned long>(&t)); }
 };
 template <typename T>
 struct my_equal {
-    bool operator()(T const& t, T const& u)
+    bool operator()(T const& t, T const& u) const
         { return &t == &u; }
 };
 


### PR DESCRIPTION
This change will be necessary to work with libstdc++.  libc++ is more permissive, accidentally.
